### PR TITLE
fix(orders): resolver error PostgreSQL y agregar manejo de excepcione…

### DIFF
--- a/backend/stockia/src/main/java/com/stockia/stockia/exceptions/order/OrderExceptionHandler.java
+++ b/backend/stockia/src/main/java/com/stockia/stockia/exceptions/order/OrderExceptionHandler.java
@@ -1,0 +1,172 @@
+package com.stockia.stockia.exceptions.order;
+
+import com.stockia.stockia.exceptions.ErrorResponse;
+import com.stockia.stockia.exceptions.product.InsufficientStockException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Collections;
+
+/**
+ * Manejador de excepciones específico para el módulo de órdenes de venta.
+ * 
+ * Tiene prioridad más alta que el GlobalExceptionHandler para proporcionar
+ * mensajes de error más específicos en el contexto de órdenes.
+ *
+ * @author StockIA Team
+ * @version 1.0
+ * @since 2025-11-30
+ */
+@RestControllerAdvice(assignableTypes = {
+        com.stockia.stockia.controllers.OrderController.class
+})
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+public class OrderExceptionHandler {
+
+    /**
+     * Maneja InsufficientStockException cuando no hay stock suficiente
+     * para completar una orden de venta.
+     * 
+     * Retorna un error 400 BAD_REQUEST con detalles del producto y stock
+     * disponible.
+     */
+    @ExceptionHandler(InsufficientStockException.class)
+    public ResponseEntity<ErrorResponse> handleInsufficientStockException(
+            InsufficientStockException ex, HttpServletRequest request) {
+
+        log.warn("Stock insuficiente en orden: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "INSUFFICIENT_STOCK",
+                "Stock insuficiente para completar la operación",
+                Collections.singletonList(ex.getMessage()),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * Maneja InvalidOrderStatusException cuando se intenta realizar una operación
+     * inválida debido al estado actual de la orden.
+     * 
+     * Ejemplos: confirmar una orden ya confirmada, cancelar una orden entregada,
+     * etc.
+     * 
+     * Retorna un error 400 BAD_REQUEST con detalles de la transición inválida.
+     */
+    @ExceptionHandler(InvalidOrderStatusException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidOrderStatusException(
+            InvalidOrderStatusException ex, HttpServletRequest request) {
+
+        log.warn("Estado de orden inválido: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "INVALID_ORDER_STATUS",
+                "Operación no permitida para el estado actual de la orden",
+                Collections.singletonList(ex.getMessage()),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * Maneja OrderNotFoundException cuando no se encuentra una orden.
+     * 
+     * Retorna un error 404 NOT_FOUND con el ID o número de orden que no se
+     * encontró.
+     */
+    @ExceptionHandler(OrderNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleOrderNotFoundException(
+            OrderNotFoundException ex, HttpServletRequest request) {
+
+        log.warn("Orden no encontrada: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "ORDER_NOT_FOUND",
+                "Orden no encontrada",
+                Collections.singletonList(ex.getMessage()),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
+     * Maneja OrderCannotBeDeletedException cuando se intenta eliminar una orden
+     * confirmada.
+     * 
+     * De acuerdo a RN-02, las órdenes confirmadas no pueden eliminarse,
+     * solo pueden cancelarse para mantener el registro histórico.
+     * 
+     * Retorna un error 409 CONFLICT indicando que debe usarse la opción de
+     * cancelar.
+     */
+    @ExceptionHandler(OrderCannotBeDeletedException.class)
+    public ResponseEntity<ErrorResponse> handleOrderCannotBeDeletedException(
+            OrderCannotBeDeletedException ex, HttpServletRequest request) {
+
+        log.warn("Intento de eliminar orden confirmada: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                "ORDER_CANNOT_BE_DELETED",
+                "La orden no puede ser eliminada",
+                Collections.singletonList(ex.getMessage()),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    /**
+     * Maneja IllegalArgumentException en el contexto de órdenes.
+     * 
+     * Proporciona mensajes de error específicos para validaciones de negocio
+     * como productos no disponibles, precios inválidos, etc.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException ex, HttpServletRequest request) {
+
+        log.warn("Argumento ilegal en orden: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "BAD_REQUEST",
+                "Datos inválidos en la orden",
+                Collections.singletonList(ex.getMessage()),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * Maneja excepciones generales en el contexto de órdenes.
+     * 
+     * Este handler captura cualquier excepción no manejada específicamente,
+     * asegurando un mensaje de error consistente en el módulo de órdenes.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(
+            Exception ex, HttpServletRequest request) {
+
+        log.error("Error inesperado en módulo de órdenes: {}", ex.getMessage(), ex);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "INTERNAL_SERVER_ERROR",
+                "Error interno al procesar la orden",
+                Collections.singletonList("Se produjo un error inesperado. Por favor, intenta más tarde."),
+                request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}


### PR DESCRIPTION
## Descripción
Este PR corrige dos problemas críticos en el módulo de órdenes:
1. **Error 500** al consultar `/api/orders` sin parámetros debido a que PostgreSQL no puede inferir tipos de parámetros `null`
2. **Excepciones genéricas poco útiles** - Las excepciones específicas de órdenes caían en el handler global retornando errores 500 en lugar de códigos HTTP apropiados (400, 404, 409)

### Cambios Principales
- Agregado `CAST(:startDate AS timestamp)` en `OrderRepository.searchOrders()` para compatibilidad con PostgreSQL
- Creado [OrderExceptionHandler](cci:2://file:///c:/Users/alexa/OneDrive/Documentos/Equipo3-noche-sp7/backend/stockia/src/main/java/com/stockia/stockia/exceptions/order/OrderExceptionHandler.java:25:0-171:1) siguiendo el patrón de [ProductCategoryExceptionHandler](cci:2://file:///c:/Users/alexa/OneDrive/Documentos/Equipo3-noche-sp7/backend/stockia/src/main/java/com/stockia/stockia/exceptions/product/ProductCategoryExceptionHandler.java:24:0-409:1) con prioridad alta (`@Order(HIGHEST_PRECEDENCE)`)
- Implementados handlers específicos para 4 excepciones del módulo de órdenes con mensajes claros y códigos HTTP correctos

## Tipo de Cambio
- [x] 🐛 Bug fix (cambio que corrige un issue)
- [x] 🔧 Refactor (mejora en el manejo de excepciones)
- [ ] ✨ Nueva feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentación
- [ ] ⚡️ Performance
- [ ] ✅ Test
- [ ] 🔨 Build

## ¿Cómo se ha probado?

### Fix PostgreSQL (OrderRepository)
- ✅ `GET /api/orders` sin parámetros → 200 OK (antes: 500 ERROR)
- ✅ `GET /api/orders?startDate=2025-11-01` → 200 OK
- ✅ `GET /api/orders?endDate=2025-11-30` → 200 OK
- ✅ `GET /api/orders?startDate=2025-11-01&endDate=2025-11-30` → 200 OK

### Exception Handlers (OrderExceptionHandler)
- ✅ Crear orden con cantidad > stock → 400 `INSUFFICIENT_STOCK`
- ✅ Confirmar orden ya confirmada → 400 `INVALID_ORDER_STATUS`
- ✅ Buscar orden inexistente → 404 `ORDER_NOT_FOUND`
- ✅ Eliminar orden confirmada → 409 `ORDER_CANNOT_BE_DELETED`

**Ejemplo de respuesta mejorada:**
```json
{
  "statusCode": 400,
  "errorCode": "INSUFFICIENT_STOCK",
  "message": "Stock insuficiente para completar la operación",
  "details": [
    "Stock insuficiente para el producto 'Laptop HP'. Stock actual: 5, cantidad requerida: 10"
  ],
  "timestamp": "2025-11-30T17:30:00Z",
  "path": "/api/orders"
}
```
## Checklist
-✅ Mi código sigue las guías de estilo del proyecto
-✅ He realizado una auto-revisión de mi código
-✅ He comentado mi código, particularmente en áreas difíciles de entender
-✅ He realizado los cambios correspondientes en la documentación
-✅ Mis cambios no generan nuevos warnings
-✅ He agregado tests que prueban que mi fix es efectivo o que mi feature funciona
-✅ Los tests nuevos y existentes pasan localmente con mis cambios
-✅ He verificado que no hay conflictos con la rama base

## Screenshots (si aplica)
Si tus cambios afectan la UI, agrega screenshots aquí.

## Información Adicional


## Ramas
- **Rama base**: dev-backend
- **Rama de origen**: fix/orders-error-details

