### PR TITLE
fix: Show loading state when downloading sale receipt

### DIFF
--- a/frontend/src/features/sales/components/confirmed/ConfirmedOrderCard.jsx
+++ b/frontend/src/features/sales/components/confirmed/ConfirmedOrderCard.jsx
@@ -2,14 +2,22 @@ import { Button } from "@/shared/components/ui/button";
 import { useDownloadSaleReceipt } from "../../hooks/useSaleTicket";
 
 function ConfirmedOrderCard({ order }) {
-  const { downloadReceipt } = useDownloadSaleReceipt();
+  const { downloadReceipt, isDownloading } = useDownloadSaleReceipt();
+
   return (
     <div className="flex flex-col p-4 border border-border rounded-lg max-w-60 max-h-36 gap-4 bg-stokia-neutral-50 shadow-md">
       <div className="flex flex-col gap-2">
         <h3 className="text-xl self-center">{order.orderNumber}</h3>
         <p className="text-sm text-stokia-neutral-600">{order.paymentNote}</p>
       </div>
-      <Button variant={"ghost"} onClick={() => downloadReceipt(order.id)}>Ver comprobante</Button>
+      <Button
+        variant="ghost"
+        className={`hover:bg-stokia-neutral-100 ${isDownloading ? 'cursor-not-allowed opacity-50' : ''}`}
+        disabled={isDownloading}
+        onClick={() => downloadReceipt(order.id)}
+      >
+        {isDownloading ? 'Descargando...' : 'Ver comprobante'}
+      </Button>
     </div>
   );
 }

--- a/frontend/src/features/sales/hooks/useSaleTicket.jsx
+++ b/frontend/src/features/sales/hooks/useSaleTicket.jsx
@@ -15,7 +15,7 @@ const downloadBlob = (blob, filename) => {
 export const useDownloadSaleReceipt = () => {
   const {
     mutateAsync: downloadReceipt,
-    isLoading: isDownloading,
+    isPending: isDownloading,
     error: downloadError
   } = useApiMutation(async (orderId) => {
     const pdfBlob = await getSaleTicket(orderId);


### PR DESCRIPTION
<img width="317" height="218" alt="image" src="https://github.com/user-attachments/assets/825a7b9f-0d24-4854-a26f-92daa3cf4c37" />

<img width="601" height="244" alt="image" src="https://github.com/user-attachments/assets/9b0d829e-2bd4-44c8-bcc7-65ce5f71add0" />
